### PR TITLE
Add `freeUserPan` prop

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -62,7 +62,8 @@ export default class GoogleMap extends Component {
     hoverDistance: PropTypes.number,
     debounced: PropTypes.bool,
     margin: PropTypes.array,
-    googleMapLoader: PropTypes.any
+    googleMapLoader: PropTypes.any,
+    freeUserPan: PropTypes.bool
   };
 
   static defaultProps = {
@@ -411,9 +412,14 @@ export default class GoogleMap extends Component {
     }
 
     if (this.map_) {
-      const centerLatLng = this.geoService_.getCenter();
-      if (nextProps.center) {
+      if (!this.props.freeUserPan && nextProps.center) {
+        const centerLatLng = this.geoService_.getCenter();
         if (Math.abs(nextProps.center[0] - centerLatLng.lat) + Math.abs(nextProps.center[1] - centerLatLng.lng) > kEPS) {
+          this.map_.panTo({lat: nextProps.center[0], lng: nextProps.center[1]});
+        }
+      } else if (this.props.freeUserPan) {
+        // Allow programatic shift of center focus via props change
+        if (Math.abs(nextProps.center[0] - this.props.center[0]) + Math.abs(nextProps.center[1] - this.props.center[1]) > kEPS) {
           this.map_.panTo({lat: nextProps.center[0], lng: nextProps.center[1]});
         }
       }


### PR DESCRIPTION
Currently when the map component enters the "receive props" lifecycle it will nuke any user pan position as it determines the provided `props.center` to be different from the current center in the geo service.

Sometimes you won't want this behaviour as you want to allow users to pan freely while the component is updated.

As a simple solution I've added a new `freeUserPan` prop. We should also consider exposing an `onPan` hook so we can keep state higher and simply pass the new center down. For now I think the new prop solution is simplest.