### PR TITLE
ensure calculation ends up with a positive integer

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -68,7 +68,7 @@ export default {
     const dx = nwWorld.x < seWorld.x
       ? seWorld.x - nwWorld.x
       : (1 - nwWorld.x) + seWorld.x;
-    const dy = seWorld.y - nwWorld.y;
+    const dy = Math.abs(seWorld.y - nwWorld.y);
 
     if (dx <= 0 && dy <= 0) {
       return null;


### PR DESCRIPTION
I've been using the utils to find the centre and zoom needed to show a number of markers on the visible map. Under some conditions we get no zoom level. I believe it's because we have some markers with negative latitude and some with positive. An Math.abs fixes the problem.