### PR TITLE
Add and implement es6-promise for ie11 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/istarkov/google-map-react#readme",
   "dependencies": {
+    "es6-promise": "^3.0.2",
     "eventemitter3": "^1.1.0",
     "lodash": "^3.10.1",
     "point-geometry": "0.0.0",

--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -1,5 +1,6 @@
 import find from 'lodash/collection/find';
 import reduce from 'lodash/collection/reduce';
+import { Promise }  from 'es6-promise';
 
 let $script_ = null;
 

--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -1,6 +1,6 @@
 import find from 'lodash/collection/find';
 import reduce from 'lodash/collection/reduce';
-import { Promise }  from 'es6-promise';
+import { Promise } from 'es6-promise';
 
 let $script_ = null;
 


### PR DESCRIPTION
Currently Internet Explorer 11 throws an error for 'Promise' not being defined. This PR utilizes this polyfill: https://github.com/jakearchibald/es6-promise to address the issue. 