### PR TITLE
Remove es6-promise module

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "react": "^0.14.0 || ^15.0.0-rc.1"
   },
   "dependencies": {
-    "es6-promise": "^3.0.2",
     "eventemitter3": "^1.1.0",
     "lodash": "^4.6.1",
     "point-geometry": "0.0.0",

--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -1,6 +1,5 @@
 import find from 'lodash/find';
 import reduce from 'lodash/reduce';
-import { Promise } from 'es6-promise';
 
 let $script_ = null;
 


### PR DESCRIPTION
Issue -  https://github.com/istarkov/google-map-react/issues/128

Was:

```
GoogleMapReact.min.js - 65732 bytes
```

Now:

```
GoogleMapReact.min.js - 58152 bytes
```

it's still works. All tests are passed.