### PR TITLE
Added this.props.center check

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -228,10 +228,14 @@ export default class GoogleMap extends Component {
 
     if (this.map_) {
       const centerLatLng = this.geoService_.getCenter();
-      if (nextProps.center) {
+      if (this._isCenterDefined(nextProps.center)) {
         const nextPropsCenter = latLng2Obj(nextProps.center);
-        const currCenter = latLng2Obj(this.props.center);
+        const currCenter = this._isCenterDefined(this.props.center) ?
+          latLng2Obj(this.props.center) :
+          null;
+
         if (
+          !currCenter ||
           Math.abs(nextPropsCenter.lat - currCenter.lat) +
           Math.abs(nextPropsCenter.lng - currCenter.lng) > kEPS
         ) {


### PR DESCRIPTION
I think there should be the check if old props center is set, otherwise latLng2Obj(this.props.center) fails.