### PR TITLE
Calculate current touch position on click (fixes #28)

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -725,6 +725,8 @@ export default class GoogleMap extends Component {
 
   _onMapClick = (event) => {
     if (this.markersDispatcher_) {
+      // support touch events and recalculate mouse position on click
+      this._onMapMouseMove(event);
       const currTime = (new Date()).getTime();
       if (currTime - this.dragTime_ > K_IDLE_TIMEOUT) {
         if (this.mouse_) {


### PR DESCRIPTION
The current mouse/finger position is calculated on mousemove only right now. To support proper touch handling, a new position is now also calculated on click. This fixes #28.

There is another issue, if you move the finger around the map, for some reason the whole site moves too (iOS 9.3). So you can't navigate inside the map without scrolling the body. This is fixable with an onTouchMove (with `e.preventDefault()`) property on the parent div container of the map. I did not add it yet, because I'm not sure if this is a react issue or google did not prevent the events from bubbeling (what is weird because I can't reproduce this issue on a stand alone map without react).
