### PR TITLE
Fix wrong decription of fitBounds() function. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ const size = {
   height: 380, // Map height in pixels
 };
 
-const {center, zoom} = fitBounds({nw, se}, size);
+const {center, zoom} = fitBounds(bounds, size);
 ```
 
 #### tile2LatLng (func)


### PR DESCRIPTION
`const {center, zoom} = fitBounds({nw, se}, size);`
{nw, se} are undefined

Need to pass bounds obect:
`const {center, zoom} = fitBounds(bounds, size);`