### PR TITLE
Added hijack scroll function

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ Example:
 
 #### googleMapLoader (func)
 
+#### hijackScroll(func)
+Allows you to takeover gmaps default scroll handler and manage scrolling over the map. Calls your function with the following arguments (scrollEvent, currentZoom, mapZoomFunction) where mapZoomFunction is map.setZoom(zoom) under the hood.
+
 #### onGoogleApiLoaded (func)
 Directly access the maps API - *use at your own risk!*
 

--- a/develop/GMap.js
+++ b/develop/GMap.js
@@ -15,7 +15,7 @@ import { susolvkaCoords, generateMarkers } from './data/fakeData';
 export const gMap = ({
   style, hoverDistance, options,
   mapParams: { center, zoom },
-  onChange, onChildMouseEnter, onChildMouseLeave,
+  onChange, onChildMouseEnter, onChildMouseLeave, hijackScroll,
   markers, draggable, // hoveredMarkerId,
 }) => (
   <GoogleMapReact
@@ -26,6 +26,7 @@ export const gMap = ({
     center={center}
     zoom={zoom}
     onChange={onChange}
+    hijackScroll={hijackScroll}
     onChildMouseEnter={onChildMouseEnter}
     onChildMouseLeave={onChildMouseLeave}
   >
@@ -72,6 +73,13 @@ export const gMapHOC = compose(
     },
     onChildMouseLeave: ({ setHoveredMarkerId }) => () => {
       setHoveredMarkerId(-1);
+    },
+    hijackScroll: () => (event, currentZoom, originalSetZoom) => {
+      const maxZoom = 20;
+      const minZoom = 1;
+      const scrollDelta = (event.wheelDelta > 0 || event.detail < 0) ? 1 : -1;
+      const newZoom = Math.max(minZoom, Math.min(maxZoom, currentZoom + scrollDelta));
+      originalSetZoom(newZoom);
     },
   }),
   withPropsOnChange(

--- a/develop/GMapOptim.js
+++ b/develop/GMapOptim.js
@@ -24,7 +24,7 @@ import props2Stream from './utils/props2Stream';
 export const gMap = ({
   style, hoverDistance, options,
   mapParams: { center, zoom },
-  onChange, onChildMouseEnter, onChildMouseLeave,
+  onChange, onChildMouseEnter, onChildMouseLeave, hijackScroll,
   markers, draggable,
 }) => (
   <GoogleMapReact
@@ -37,6 +37,7 @@ export const gMap = ({
     onChildMouseEnter={onChildMouseEnter}
     onChildMouseLeave={onChildMouseLeave}
     draggable={draggable}
+    hijackScroll={hijackScroll}
     experimental
   >
     {markers}
@@ -80,6 +81,13 @@ export const gMapHOC = compose(
     },
     onChildMouseLeave: ({ setHoveredMarkerId }) => () => {
       setHoveredMarkerId(-1);
+    },
+    hijackScroll: () => (event, currentZoom, originalSetZoom) => {
+      const maxZoom = 20;
+      const minZoom = 1;
+      const scrollDelta = (event.wheelDelta > 0 || event.detail < 0) ? 1 : -1;
+      const newZoom = Math.max(minZoom, Math.min(maxZoom, currentZoom + scrollDelta));
+      originalSetZoom(newZoom);
     },
   }),
   withPropsOnChange(

--- a/develop/tests/playground.spec.js
+++ b/develop/tests/playground.spec.js
@@ -10,7 +10,7 @@ describe('Playground', () => {
     const props$ = (new BehaviorSubject(1))
       .distinctUntilChanged(comparator);
 
-    props$.subscribe(v => console.log(v));
+    props$.subscribe(v => console.log(v)); // eslint-disable-line
     props$.next(1);
     props$.next(2);
     props$.next(1);

--- a/src/google_map_markers.js
+++ b/src/google_map_markers.js
@@ -170,7 +170,7 @@ export default class GoogleMapMarkers extends Component {
     }
   }
 
-  _onMouseChangeHandler_raf = () => {
+  _onMouseChangeHandler_raf = () => { // eslint-disable-line
     if (!this.dimesionsCache_) {
       return;
     }


### PR DESCRIPTION
@istarkov I've added a hijack scroll function that allows you to manipulate the scroll event

I couldn't find any PR instructions so please let me know if there's any issues or if you'd like me for example to write tests.

Example uses:
* You'd like to zoom only multiples of 2 on scroll
* Implement a custom info-window (see https://github.com/istarkov/google-map-react/issues/180) or any other component that has a scroll bar. This is my use-case - I use this function to hijack the scroll event and then zoom only if I'm not inside a scrollable component.

Also note that I've added some example functions into the demo files to show how it works, but because the demo maps call `setMapParams` on `onChange` events you don't get a smooth zoom change but instead get a slightly slower zoom change from changing the zoom props.

I can remove these from the demo if you like but thought it might be useful for you to test.