### PR TITLE
Compare LatLngLiteral objects by value to avoid warnings

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -23,6 +23,7 @@ import log2 from './utils/math/log2';
 import isNumber from './utils/isNumber';
 import omit from './utils/omit';
 import detectElementResize from './utils/detectElementResize';
+import latLngAreEqual from './utils/latLngAreEqual';
 
 const kEPS = 0.00001;
 const K_GOOGLE_TILE_SIZE = 256;
@@ -220,7 +221,7 @@ export default class GoogleMap extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (process.env.NODE_ENV !== 'production') {
-      if (this.props.defaultCenter !== nextProps.defaultCenter) {
+      if (!latLngAreEqual(this.props.defaultCenter, nextProps.defaultCenter)) {
         console.warn('GoogleMap: defaultCenter prop changed. ' +  // eslint-disable-line
                       'You can\'t change default props.');
       }

--- a/src/utils/latLngAreEqual.js
+++ b/src/utils/latLngAreEqual.js
@@ -1,0 +1,15 @@
+// Determines if two LatLngLiteral objects are equal, not just by reference
+// but by their properties
+export default function latLngAreEqual(latLng1, latLng2) {
+  if (latLng1 === latLng2) {
+    // Reference equality
+    return true;
+  }
+  if (typeof latLng1 !== 'object' || typeof latLng2 !== 'object') {
+    // Check for nulls/invalid types
+    return false;
+  }
+  const { lat1, lng1 } = latLng1;
+  const { lat2, lng2 } = latLng2;
+  return lat1 === lat2 &&lng1 === lng2;
+};


### PR DESCRIPTION
The way my web application is set up, it uses a lot of immutable objects that are copied. This means that the properties I feed into the GoogleMap component can be equal according to their values, but not by reference because they are technically different objects.

I was getting a lot of warnings from google-map-react saying that I was changing the `defaultCenter` property after it was initially set. I checked and the values were not actually changing but each object was new so the `===` equality comparison was not working in that instance.

I have added a function to compare by value. Do you think this is a worthwhile change? I have tested it locally in my project and it seems to be working well.

I didn't know whether to use a shallow compare library like `react-addons-shallow-compare` (https://facebook.github.io/react/docs/shallow-compare.html). On one hand a 3rd party library could possibly cover edge cases I hadn't thought of but also it is another dependency to pull into the project and make the final file size bigger.

Let me know what you think.

Thanks!