### PR TITLE
Prevent new Promise() call before initializing polyfill.

### DIFF
--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -3,12 +3,13 @@ let $script_ = null;
 let loadPromise_;
 
 let resolveCustomPromise_;
-const _customPromise = new Promise(resolve => {
-  resolveCustomPromise_ = resolve;
-});
 
 // TODO add libraries language and other map options
 export default function googleMapLoader(bootstrapURLKeys) {
+  const _customPromise = new Promise(resolve => {
+    resolveCustomPromise_ = resolve;
+  });
+
   if (!$script_) {
     $script_ = require('scriptjs'); // eslint-disable-line
   }


### PR DESCRIPTION
Prevent `new Promise()` call before initializing polyfill.

Currently, it calls `new Promise()` in outside of the function. 
if you bundle this component with entry module via Webpack, `Promise is not defined` error occurs on page initialize. IE and many android devices still have this problem.