### PR TITLE
Keep original center on _mapDomResizeCallback

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -390,7 +390,9 @@ export default class GoogleMap extends Component {
   _mapDomResizeCallback = () => {
     this.resetSizeOnIdle_ = true;
     if (this.maps_) {
+      const originalCenter = this.maps_.getCenter();
       this.maps_.event.trigger(this.map_, 'resize');
+      this.maps_.setCenter(originalCenter);
     }
   }
 


### PR DESCRIPTION
When the resize event is triggered, the original center was lost. 
This issue is significant when the map is renders outside visible dom with zero height and width.
When placed into the visible dom, the resize is triggered correctly. With this change the center will persist. (Without this fix the old center is the top left corner)