### PR TITLE
Fix reference to maps instead of map

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -391,9 +391,9 @@ export default class GoogleMap extends Component {
   _mapDomResizeCallback = () => {
     this.resetSizeOnIdle_ = true;
     if (this.maps_) {
-      const originalCenter = this.maps_.getCenter();
+      const originalCenter = this.map_.getCenter();
       this.maps_.event.trigger(this.map_, 'resize');
-      this.maps_.setCenter(originalCenter);
+      this.map_.setCenter(originalCenter);
     }
   }
 


### PR DESCRIPTION
Sorry, made a smal but ugly mistake in the last pull request.
The this.maps does not have a function getCenter .... but this.map does.