### PR TITLE
Fix unresponsive map after outside-click on a touch device with draggable:false

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -645,10 +645,10 @@ export default class GoogleMap extends Component {
       });
 
       // an alternative way to know the mouse is back within the map
-      // This would not fire when clicking/interacting with google maps own on-map countrols+markers.
-      // This handles an edge case for touch devices + 'draggable:false' custom option.
-      // See #332
-      maps.event.addListener(map, 'click', () => { 
+      // This would not fire when clicking/interacting with google maps
+      // own on-map countrols+markers. This handles an edge case for touch devices
+      // + 'draggable:false' custom option. See #332 for more details.
+      maps.event.addListener(map, 'click', () => {
         this_.mouseInMap_ = true;
       });
 

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -644,6 +644,14 @@ export default class GoogleMap extends Component {
         this_.mouseInMap_ = true;
       });
 
+      // an alternative way to know the mouse is back within the map
+      // This would not fire when clicking/interacting with google maps own on-map countrols+markers.
+      // This handles an edge case for touch devices + 'draggable:false' custom option.
+      // See #332
+      maps.event.addListener(map, 'click', () => { 
+        this_.mouseInMap_ = true;
+      });
+
       maps.event.addListener(map, 'mouseout', () => { // has advantage over div MouseLeave
         this_.mouseInMap_ = false;
         this_.mouse_ = null;


### PR DESCRIPTION
This fixes #332 with a workaround for the detection of the presence of the mouse in the map.
See the original issue for reproduction and root cause.