### PR TITLE
Allow the developer to specify prop `mapTypeId`

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -94,6 +94,7 @@ export default class GoogleMap extends Component {
     ]),
     defaultZoom: PropTypes.number,
     zoom: PropTypes.number,
+    mapTypeId: PropTypes.oneOf(['hybrid', 'roadmap', 'satellite', 'terrain']),
     onBoundsChange: PropTypes.func,
     onChange: PropTypes.func,
     onClick: PropTypes.func,
@@ -501,6 +502,7 @@ export default class GoogleMap extends Component {
         const propsOptions = {
           zoom: this.props.zoom || this.props.defaultZoom,
           center: new maps.LatLng(centerLatLng.lat, centerLatLng.lng),
+          mapTypeId: this.props.mapTypeId || 'roadmap',
         };
 
         // prevent to exapose full api


### PR DESCRIPTION
Hello,

Any interest and allowing developers to specify `mapTypeId`? This allows us to instantiate the component with a specific map type (like "hybrid").

Thanks!
Anthony