### PR TITLE
Do a proper check for object equality

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -276,7 +276,8 @@ export default class GoogleMap extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (process.env.NODE_ENV !== 'production') {
-      if (this.props.defaultCenter !== nextProps.defaultCenter) {
+      if ((isPlainObject(nextProps) && !areObjectsEqual(this.props.defaultCenter, nextProps.defaultCenter))
+          || (!isPlainObject(nextProps.defaultCenter) && !isArraysEqualEps(this.props.defaultCenter, nextProps.defaultCenter))) {
         console.warn(
           'GoogleMap: defaultCenter prop changed. ' + // eslint-disable-line
             "You can't change default props."

--- a/src/utils/objectEquality.js
+++ b/src/utils/objectEquality.js
@@ -1,0 +1,25 @@
+export default function areObjectsEqual(a, b) {
+    // Create arrays of property names
+    var aProps = Object.getOwnPropertyNames(a);
+    var bProps = Object.getOwnPropertyNames(b);
+
+    // If number of properties is different,
+    // objects are not equivalent
+    if (aProps.length != bProps.length) {
+        return false;
+    }
+
+    for (var i = 0; i < aProps.length; i++) {
+        var propName = aProps[i];
+
+        // If values of same property are not equal,
+        // objects are not equivalent
+        if (a[propName] !== b[propName]) {
+            return false;
+        }
+    }
+
+    // If we made it this far, objects
+    // are considered equivalent
+    return true;
+}


### PR DESCRIPTION
Previously we were just using a simple '==' to check if
new defaultCenter was equal to old defaultCenter. However,
defaultCenter is an object, and therefore '==' will always
return false unless they reference the same object in memory.
Instead we should do a proper comparison of the properties
of the object.