### PR TITLE
Added heatmap functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ npm install --save google-map-react
 * Example project:
 [main](http://istarkov.github.io/google-map-react/map/main/) ([source](https://github.com/istarkov/google-map-react-examples/blob/master/web/flux/components/examples/x_main/main_map_block.jsx)); [balderdash](http://istarkov.github.io/google-map-react/map/balderdash/) (same source as main)
 
-* Clustering example (**new**)
+* Clustering example ([source](https://github.com/istarkov/google-map-clustering-example))
 [google-map-clustering-example](http://istarkov.github.io/google-map-clustering-example/)
 
 * How to render thousands of markers (**new**)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,79 @@ It renders components on the map before (and even without) the Google Maps API l
 
 There is no need to place a `<script src=` tag at top of page. The Google Maps API loads upon the first usage of the `GoogleMapReact` component.
 
+### Heatmap Layer
+
+For enabling heatmap layer, just add `heatmapLibrary={true}` and provide data for heatmap in `heatmap` as props.
+
+#### Example
+
+```javascript
+<GoogleMapReact
+    draggable={draggable}
+    style={style}
+    options={options}
+    hoverDistance={hoverDistance}
+    center={center}
+    zoom={zoom}
+    onChange={onChange}
+    onChildMouseEnter={onChildMouseEnter}
+    onChildMouseLeave={onChildMouseLeave}
+    resetBoundsOnResize={true}
+    apiKey={'AIzaSyC-BebC7ChnHPzxQm7DAHYFMCqR5H3Jlps'}
+    heatmapLibrary={true}
+    heatmap={{
+      positions: [
+        {
+          lat: 60.714305,
+          lng: 47.051773,
+        },
+        {
+          lat: 60.734305,
+          lng: 47.061773,
+        },
+        {
+          lat: 60.754305,
+          lng: 47.081773,
+        },
+        {
+          lat: 60.774305,
+          lng: 47.101773,
+        },
+        {
+          lat: 60.804305,
+          lng: 47.111773,
+        },
+      ],
+      options: {
+        radius: 20,
+        opacity: 0.7,
+        gradient: [
+          'rgba(0, 255, 255, 0)',
+          'rgba(0, 255, 255, 1)',
+          'rgba(0, 191, 255, 1)',
+          'rgba(0, 127, 255, 1)',
+          'rgba(0, 63, 255, 1)',
+          'rgba(0, 0, 255, 1)',
+          'rgba(0, 0, 223, 1)',
+          'rgba(0, 0, 191, 1)',
+          'rgba(0, 0, 159, 1)',
+          'rgba(0, 0, 127, 1)',
+          'rgba(63, 0, 91, 1)',
+          'rgba(127, 0, 63, 1)',
+          'rgba(191, 0, 31, 1)',
+          'rgba(255, 0, 0, 1)'
+        ]
+      },
+    }}
+  >
+    {markers}
+  </GoogleMapReact>
+```
+
+#### Important Note
+
+If you have multiple `GoogleMapReact` components in project and you want to use heatmap layer so provide `heatmapLibrary={true}` for all `GoogleMapReact` components so component will load heatmap library at the beginning with google map api.
+
 ### Internal Hover Algorithm
 
 Now every object on the map can be hovered (however, you can still use css hover selectors if you want). If you try zooming out here [example](http://istarkov.github.io/google-map-react/map/main), you will still be able to hover on almost every map marker.

--- a/develop/GMap.js
+++ b/develop/GMap.js
@@ -36,6 +36,24 @@ export const gMap = (
     onChange={onChange}
     onChildMouseEnter={onChildMouseEnter}
     onChildMouseLeave={onChildMouseLeave}
+    heatmapPositions={[
+      {
+        lat: 24.075,
+        lng: 54.947,
+      },
+      {
+        lat: 24.075,
+        lng: 54.940,
+      },
+      {
+        lat: 24.075,
+        lng: 54.943,
+      },
+      {
+        lat: 37.782,
+        lng: -122.445,
+      },
+    ]}
   >
     {markers}
   </GoogleMapReact>

--- a/develop/GMap.js
+++ b/develop/GMap.js
@@ -36,24 +36,6 @@ export const gMap = (
     onChange={onChange}
     onChildMouseEnter={onChildMouseEnter}
     onChildMouseLeave={onChildMouseLeave}
-    heatmapPositions={[
-      {
-        lat: 24.075,
-        lng: 54.947,
-      },
-      {
-        lat: 24.075,
-        lng: 54.940,
-      },
-      {
-        lat: 24.075,
-        lng: 54.943,
-      },
-      {
-        lat: 37.782,
-        lng: -122.445,
-      },
-    ]}
   >
     {markers}
   </GoogleMapReact>

--- a/develop/GMap.js
+++ b/develop/GMap.js
@@ -36,6 +36,7 @@ export const gMap = (
     onChange={onChange}
     onChildMouseEnter={onChildMouseEnter}
     onChildMouseLeave={onChildMouseLeave}
+    heatmapLibrary={true}
   >
     {markers}
   </GoogleMapReact>

--- a/develop/GMapHeatmap.js
+++ b/develop/GMapHeatmap.js
@@ -1,0 +1,103 @@
+/* eslint-disable */
+import React, { PropTypes } from 'react';
+import compose from 'recompose/compose';
+import defaultProps from 'recompose/defaultProps';
+import withStateSelector from './utils/withStateSelector';
+import withHandlers from 'recompose/withHandlers';
+import withState from 'recompose/withState';
+import withContext from 'recompose/withContext';
+import withProps from 'recompose/withProps';
+import withPropsOnChange from 'recompose/withPropsOnChange';
+import ptInBounds from './utils/ptInBounds';
+import GoogleMapReact from '../src';
+import SimpleMarker from './markers/SimpleMarker';
+import { createSelector } from 'reselect';
+import { susolvkaCoords, generateMarkers, heatmapData } from './data/fakeData';
+
+export const gMapHeatmap = (
+  {
+    style,
+    hoverDistance,
+    options,
+    mapParams: { center, zoom },
+    onChange,
+    onChildMouseEnter,
+    onChildMouseLeave,
+    markers,
+    draggable, // hoveredMarkerId,
+  }
+) => (
+  <GoogleMapReact
+    draggable={draggable}
+    style={style}
+    options={options}
+    hoverDistance={hoverDistance}
+    center={center}
+    zoom={zoom}
+    onChange={onChange}
+    onChildMouseEnter={onChildMouseEnter}
+    onChildMouseLeave={onChildMouseLeave}
+    resetBoundsOnResize={true}
+    apiKey={'AIzaSyC-BebC7ChnHPzxQm7DAHYFMCqR5H3Jlps'}
+    heatmap={heatmapData}
+  >
+    {markers}
+  </GoogleMapReact>
+);
+
+export const gMapHOC = compose(
+  defaultProps({
+    clusterRadius: 60,
+    hoverDistance: 30,
+    options: {
+      minZoom: 3,
+      maxZoom: 15,
+    },
+    style: {
+      position: 'relative',
+      margin: 10,
+      padding: 10,
+      flex: 1,
+    },
+  }),
+  withContext({ hello: PropTypes.string }, () => ({ hello: 'world' })),
+  // withState so you could change markers if you want
+  withStateSelector('markers', 'setMarkers', () =>
+    createSelector(
+      ({ route: { markersCount = 20 } }) => markersCount,
+      markersCount => generateMarkers(markersCount)
+    )),
+  withState('hoveredMarkerId', 'setHoveredMarkerId', -1),
+  withState('mapParams', 'setMapParams', { center: susolvkaCoords, zoom: 6 }),
+  // describe events
+  withHandlers({
+    onChange: ({ setMapParams }) =>
+      ({ center, zoom, bounds }) => {
+        setMapParams({ center, zoom, bounds });
+      },
+    onChildMouseEnter: ({ setHoveredMarkerId }) =>
+      (hoverKey, { id }) => {
+        setHoveredMarkerId(id);
+      },
+    onChildMouseLeave: ({ setHoveredMarkerId }) =>
+      () => {
+        setHoveredMarkerId(-1);
+      },
+  }),
+  withPropsOnChange(['markers', 'mapParams'], ({
+    markers,
+    mapParams: { bounds },
+  }) => ({
+    markers: bounds ? markers.filter(m => ptInBounds(bounds, m)) : [],
+  })),
+  withProps(({ hoveredMarkerId }) => ({
+    draggable: hoveredMarkerId === -1,
+  })),
+  withPropsOnChange(['markers'], ({ markers }) => ({
+    markers: markers.map(({ ...markerProps, id }) => (
+      <SimpleMarker key={id} id={id} {...markerProps} />
+    )),
+  }))
+);
+
+export default gMapHOC(gMapHeatmap);

--- a/develop/GMapHeatmap.js
+++ b/develop/GMapHeatmap.js
@@ -40,7 +40,6 @@ export const gMapHeatmap = (
     onChange={onChange}
     onChildMouseEnter={onChildMouseEnter}
     onChildMouseLeave={onChildMouseLeave}
-    resetBoundsOnResize={true}
     heatmapLibrary={true}
     heatmap={heatmapData}
   >

--- a/develop/GMapHeatmap.js
+++ b/develop/GMapHeatmap.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {
   compose,
   defaultProps,

--- a/develop/GMapHeatmap.js
+++ b/develop/GMapHeatmap.js
@@ -41,7 +41,6 @@ export const gMapHeatmap = (
     onChildMouseEnter={onChildMouseEnter}
     onChildMouseLeave={onChildMouseLeave}
     resetBoundsOnResize={true}
-    apiKey={'AIzaSyC-BebC7ChnHPzxQm7DAHYFMCqR5H3Jlps'}
     heatmapLibrary={true}
     heatmap={heatmapData}
   >

--- a/develop/GMapHeatmap.js
+++ b/develop/GMapHeatmap.js
@@ -41,6 +41,7 @@ export const gMapHeatmap = (
     onChildMouseLeave={onChildMouseLeave}
     resetBoundsOnResize={true}
     apiKey={'AIzaSyC-BebC7ChnHPzxQm7DAHYFMCqR5H3Jlps'}
+    heatmapLibrary={true}
     heatmap={heatmapData}
   >
     {markers}

--- a/develop/GMapHeatmap.js
+++ b/develop/GMapHeatmap.js
@@ -1,17 +1,19 @@
-/* eslint-disable */
 import React, { PropTypes } from 'react';
-import compose from 'recompose/compose';
-import defaultProps from 'recompose/defaultProps';
+import {
+  compose,
+  defaultProps,
+  withHandlers,
+  withState,
+  withContext,
+  withProps,
+  withPropsOnChange,
+} from 'recompose';
+import { createSelector } from 'reselect';
+
 import withStateSelector from './utils/withStateSelector';
-import withHandlers from 'recompose/withHandlers';
-import withState from 'recompose/withState';
-import withContext from 'recompose/withContext';
-import withProps from 'recompose/withProps';
-import withPropsOnChange from 'recompose/withPropsOnChange';
 import ptInBounds from './utils/ptInBounds';
 import GoogleMapReact from '../src';
 import SimpleMarker from './markers/SimpleMarker';
-import { createSelector } from 'reselect';
 import { susolvkaCoords, generateMarkers, heatmapData } from './data/fakeData';
 
 export const gMapHeatmap = (

--- a/develop/GMapLayers.js
+++ b/develop/GMapLayers.js
@@ -41,6 +41,7 @@ export const gMap = (
     onChange={onChange}
     onChildMouseEnter={onChildMouseEnter}
     onChildMouseLeave={onChildMouseLeave}
+    heatmapLibrary={true}
   >
     {markers}
   </GoogleMapReact>

--- a/develop/GMapOptim.js
+++ b/develop/GMapOptim.js
@@ -45,6 +45,7 @@ export const gMap = (
     onChildMouseLeave={onChildMouseLeave}
     draggable={draggable}
     experimental
+    heatmapLibrary={true}
   >
     {markers}
   </GoogleMapReact>

--- a/develop/GMapResizable.js
+++ b/develop/GMapResizable.js
@@ -39,6 +39,7 @@ export const gMapResizable = (
     onChildMouseLeave={onChildMouseLeave}
     resetBoundsOnResize={true}
     apiKey={'AIzaSyC-BebC7ChnHPzxQm7DAHYFMCqR5H3Jlps'}
+    heatmapLibrary={true}
   >
     {markers}
   </GoogleMapReact>

--- a/develop/Layout.js
+++ b/develop/Layout.js
@@ -20,6 +20,7 @@ export class Layout extends Component {
             <Link to="/hoverunoptim">Hover unoptim</Link>
             <Link to="/hoveroptim">Hover optim</Link>
             <Link to="/resizable">Resizable Map</Link>
+            <Link to="/heatmap">Heatmap</Link>
           </div>
           <div>
             <a href="https://github.com/istarkov/google-map-clustering-example">

--- a/develop/Main.js
+++ b/develop/Main.js
@@ -9,6 +9,7 @@ import GMap from './GMap';
 import GMapLayers from './GMapLayers';
 import GMapOptim from './GMapOptim';
 import GMapResizable from './GMapResizable';
+import GMapHeatmap from './GMapHeatmap';
 import './Main.sass';
 
 const mountNode = document.getElementById('app');
@@ -20,6 +21,7 @@ render(
       <Route markersCount={50} path="layers" component={GMapLayers} />
       <Route markersCount={50} path="hoveroptim" component={GMapOptim} />
       <Route markersCount={20} path="resizable" component={GMapResizable} />
+      <Route markersCount={20} path="heatmap" component={GMapHeatmap} />
       <IndexRoute markersCount={20} component={GMap} />
     </Route>
   </Router>,

--- a/develop/data/fakeData.js
+++ b/develop/data/fakeData.js
@@ -19,3 +19,32 @@ export const generateMarkers = count =>
         Math.cos(50 * Math.PI * index / 180) +
       Math.sin(5 * index / 180),
   }));
+
+export const heatmapData = {
+  positions: [
+    {
+      lat: 60.714305,
+      lng: 47.051773,
+    },
+    {
+      lat: 60.734305,
+      lng: 47.061773,
+    },
+    {
+      lat: 60.754305,
+      lng: 47.081773,
+    },
+    {
+      lat: 60.774305,
+      lng: 47.101773,
+    },
+    {
+      lat: 60.804305,
+      lng: 47.111773,
+    },
+  ],
+  options: {
+    radius: 20,
+    opacity: 0.7,
+  },
+};

--- a/src/google_heatmap.js
+++ b/src/google_heatmap.js
@@ -1,7 +1,7 @@
 import fp from 'lodash/fp';
 
-export const generateHeatmap = (instance, { positions }) => {
-  return new instance.visualization.HeatmapLayer({
+export const generateHeatmap = (instance, { positions }) =>
+  new instance.visualization.HeatmapLayer({
     data: fp.reduce(
       (acc, { lat, lng }) => {
         acc.push({
@@ -13,11 +13,9 @@ export const generateHeatmap = (instance, { positions }) => {
       positions
     ),
   });
-};
 
-export const optionsHeatmap = (instance, { options }) => {
-  return fp.map(
+export const optionsHeatmap = (instance, { options }) =>
+  fp.map(
     option => instance.set(option, options[option]),
     Object.keys(options || {})
   );
-};

--- a/src/google_heatmap.js
+++ b/src/google_heatmap.js
@@ -15,8 +15,9 @@ export const generateHeatmap = (instance, { positions }) => {
   });
 };
 
-export const optionsHeatmap = (instance, { options }) =>
-  fp.map(
+export const optionsHeatmap = (instance, { options }) => {
+  return fp.map(
     option => instance.set(option, options[option]),
     Object.keys(options || {})
   );
+};

--- a/src/google_heatmap.js
+++ b/src/google_heatmap.js
@@ -1,0 +1,16 @@
+import fp from 'lodash/fp';
+
+export default (instance, data = []) => {
+  return new instance.visualization.HeatmapLayer({
+    data: fp.reduce(
+      (acc, { lat, lng }) => {
+        acc.push({
+          location: new instance.LatLng(lat, lng),
+        });
+        return acc;
+      },
+      [],
+      data
+    ),
+  });
+};

--- a/src/google_heatmap.js
+++ b/src/google_heatmap.js
@@ -1,6 +1,6 @@
 import fp from 'lodash/fp';
 
-export default (instance, data = []) => {
+export const generateHeatmap = (instance, { positions }) => {
   return new instance.visualization.HeatmapLayer({
     data: fp.reduce(
       (acc, { lat, lng }) => {
@@ -10,7 +10,13 @@ export default (instance, data = []) => {
         return acc;
       },
       [],
-      data
+      positions
     ),
   });
 };
+
+export const optionsHeatmap = (instance, { options }) =>
+  fp.map(
+    option => instance.set(option, options[option]),
+    Object.keys(options || {})
+  );

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -10,7 +10,7 @@ import MarkerDispatcher from './marker_dispatcher';
 import GoogleMapMap from './google_map_map';
 import GoogleMapMarkers from './google_map_markers';
 import GoogleMapMarkersPrerender from './google_map_markers_prerender';
-import * as GoogleHeatmap from './google_heatmap';
+import { generateHeatmap, optionsHeatmap } from './google_heatmap';
 
 import googleMapLoader from './utils/loaders/google_map_loader';
 import detectBrowser from './utils/detect';
@@ -508,9 +508,9 @@ export default class GoogleMap extends Component {
 
         // Start Heatmap
         Object.assign(this, {
-          heatmap: GoogleHeatmap.generateHeatmap(maps, this.props.heatmap),
+          heatmap: generateHeatmap(maps, this.props.heatmap),
         });
-        GoogleHeatmap.optionsHeatmap(this.heatmap, this.props.heatmap);
+        optionsHeatmap(this.heatmap, this.props.heatmap);
         // End Heatmap
 
         // prevent to exapose full api

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -142,7 +142,7 @@ export default class GoogleMap extends Component {
       position: 'relative',
     },
     layerTypes: [],
-    heatmap: [],
+    heatmap: {},
   };
 
   static googleMapLoader = googleMapLoader; // eslint-disable-line

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -143,6 +143,7 @@ export default class GoogleMap extends Component {
     },
     layerTypes: [],
     heatmap: {},
+    heatmapLibrary: false,
   };
 
   static googleMapLoader = googleMapLoader; // eslint-disable-line
@@ -256,7 +257,7 @@ export default class GoogleMap extends Component {
       ...this.props.bootstrapURLKeys,
     };
 
-    this.props.googleMapLoader(bootstrapURLKeys); // we can start load immediatly
+    this.props.googleMapLoader(bootstrapURLKeys, this.props.heatmapLibrary); // we can start load immediatly
 
     setTimeout(
       () => {
@@ -493,7 +494,7 @@ export default class GoogleMap extends Component {
     };
 
     this.props
-      .googleMapLoader(bootstrapURLKeys)
+      .googleMapLoader(bootstrapURLKeys, this.props.heatmapLibrary)
       .then(maps => {
         if (!this.mounted_) {
           return;
@@ -507,10 +508,12 @@ export default class GoogleMap extends Component {
         };
 
         // Start Heatmap
-        Object.assign(this, {
-          heatmap: generateHeatmap(maps, this.props.heatmap),
-        });
-        optionsHeatmap(this.heatmap, this.props.heatmap);
+        if (this.props.heatmap.positions) {
+          Object.assign(this, {
+            heatmap: generateHeatmap(maps, this.props.heatmap),
+          });
+          optionsHeatmap(this.heatmap, this.props.heatmap);
+        }
         // End Heatmap
 
         // prevent to exapose full api
@@ -649,7 +652,7 @@ export default class GoogleMap extends Component {
         this.overlay_ = overlay;
 
         overlay.setMap(map);
-        this.heatmap.setMap(map);
+        this.props.heatmap.positions && this.heatmap.setMap(map);
 
         maps.event.addListener(map, 'zoom_changed', () => {
           // recalc position at zoom start

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -10,6 +10,7 @@ import MarkerDispatcher from './marker_dispatcher';
 import GoogleMapMap from './google_map_map';
 import GoogleMapMarkers from './google_map_markers';
 import GoogleMapMarkersPrerender from './google_map_markers_prerender';
+import GoogleHeatmap from './google_heatmap';
 
 import googleMapLoader from './utils/loaders/google_map_loader';
 import detectBrowser from './utils/detect';
@@ -141,6 +142,7 @@ export default class GoogleMap extends Component {
       position: 'relative',
     },
     layerTypes: [],
+    heatmapPositions: [],
   };
 
   static googleMapLoader = googleMapLoader; // eslint-disable-line
@@ -154,6 +156,7 @@ export default class GoogleMap extends Component {
     this.map_ = null;
     this.maps_ = null;
     this.prevBounds_ = null;
+    this.heatmap = null;
 
     this.layers_ = {};
 
@@ -503,6 +506,12 @@ export default class GoogleMap extends Component {
           center: new maps.LatLng(centerLatLng.lat, centerLatLng.lng),
         };
 
+        // Start Heatmap
+        this.heatmap = GoogleHeatmap(maps, this.props.heatmapPositions);
+        this.heatmap.set('radius', 30);
+        this.heatmap.set('opacity', 0.8);
+        // End Heatmap
+
         // prevent to exapose full api
         // next props must be exposed (console.log(Object.keys(pick(maps, isPlainObject))))
         // "Animation", "ControlPosition", "MapTypeControlStyle", "MapTypeId",
@@ -639,6 +648,7 @@ export default class GoogleMap extends Component {
         this.overlay_ = overlay;
 
         overlay.setMap(map);
+        this.heatmap.setMap(map);
 
         maps.event.addListener(map, 'zoom_changed', () => {
           // recalc position at zoom start

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -652,7 +652,9 @@ export default class GoogleMap extends Component {
         this.overlay_ = overlay;
 
         overlay.setMap(map);
-        this.props.heatmap.positions && this.heatmap.setMap(map);
+        if (this.props.heatmap.positions) {
+          this.heatmap.setMap(map);
+        }
 
         maps.event.addListener(map, 'zoom_changed', () => {
           // recalc position at zoom start

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -10,7 +10,7 @@ import MarkerDispatcher from './marker_dispatcher';
 import GoogleMapMap from './google_map_map';
 import GoogleMapMarkers from './google_map_markers';
 import GoogleMapMarkersPrerender from './google_map_markers_prerender';
-import GoogleHeatmap from './google_heatmap';
+import * as GoogleHeatmap from './google_heatmap';
 
 import googleMapLoader from './utils/loaders/google_map_loader';
 import detectBrowser from './utils/detect';
@@ -142,7 +142,7 @@ export default class GoogleMap extends Component {
       position: 'relative',
     },
     layerTypes: [],
-    heatmapPositions: [],
+    heatmap: [],
   };
 
   static googleMapLoader = googleMapLoader; // eslint-disable-line
@@ -507,9 +507,10 @@ export default class GoogleMap extends Component {
         };
 
         // Start Heatmap
-        this.heatmap = GoogleHeatmap(maps, this.props.heatmapPositions);
-        this.heatmap.set('radius', 30);
-        this.heatmap.set('opacity', 0.8);
+        Object.assign(this, {
+          heatmap: GoogleHeatmap.generateHeatmap(maps, this.props.heatmap),
+        });
+        GoogleHeatmap.optionsHeatmap(this.heatmap, this.props.heatmap);
         // End Heatmap
 
         // prevent to exapose full api

--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -63,7 +63,7 @@ export default function googleMapLoader(bootstrapURLKeys) {
     );
 
     $script_(
-      `https://maps.googleapis.com/maps/api/js?callback=_$_google_map_initialize_$_${queryString}`,
+      `https://maps.googleapis.com/maps/api/js?callback=_$_google_map_initialize_$_${queryString}&libraries=visualization`,
       () =>
         typeof window.google === 'undefined' &&
         reject(new Error('google map initialization error (not loaded)'))

--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -60,7 +60,7 @@ export default function googleMapLoader(bootstrapURLKeys, heatmapLibrary) {
       (r, key) => `${r}&${key}=${bootstrapURLKeys[key]}`,
       ''
     );
-    
+
     const libraries = heatmapLibrary ? '&libraries=visualization' : '';
     const url = bootstrapURLKeys.region &&
       bootstrapURLKeys.region.toLowerCase() === 'cn'

--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -9,7 +9,7 @@ const _customPromise = new Promise(resolve => {
 });
 
 // TODO add libraries language and other map options
-export default function googleMapLoader(bootstrapURLKeys) {
+export default function googleMapLoader(bootstrapURLKeys, heatmapLibrary) {
   if (!$script_) {
     $script_ = require('scriptjs'); // eslint-disable-line
   }
@@ -23,7 +23,6 @@ export default function googleMapLoader(bootstrapURLKeys) {
   if (loadPromise_) {
     return loadPromise_;
   }
-
   loadPromise_ = new Promise((resolve, reject) => {
     if (typeof window === 'undefined') {
       reject(new Error('google map cannot be loaded outside browser env'));
@@ -62,8 +61,10 @@ export default function googleMapLoader(bootstrapURLKeys) {
       ''
     );
 
+    const libraries = heatmapLibrary ? '&libraries=visualization' : '';
+
     $script_(
-      `https://maps.googleapis.com/maps/api/js?callback=_$_google_map_initialize_$_${queryString}&libraries=visualization`,
+      `https://maps.googleapis.com/maps/api/js?callback=_$_google_map_initialize_$_${queryString}${libraries}`,
       () =>
         typeof window.google === 'undefined' &&
         reject(new Error('google map initialization error (not loaded)'))


### PR DESCRIPTION
Hi, I have added heatmap functionality which is from default google map api.

**How it works**
Just need to pass prop of heatmap with GoogleMapReact component and all heatmap options are available like radius, opacity and gradient.

**Example**
```
<GoogleMapComp
  lat={this.props.lat}
  lng={this.props.lng}
  zoom={this.props.zoom}
  products={this.props.products}
  heatmap={{
    positions: [{
        lat: 24.075,
        lng: 54.947,
      },
      {
        lat: 24.075,
        lng: 54.940,
      },
      {
        lat: 24.075,
        lng: 54.943,
      },
      {
        lat: 24.075,
        lng: 54.933,
      },
      {
        lat: 24.075,
        lng: 54.923,
      }],
      options: {
        radius: 20,
        opacity: 0.7,
        gradient: [
          'rgba(0, 255, 255, 0)',
          'rgba(0, 255, 255, 1)',
          'rgba(0, 191, 255, 1)',
          'rgba(0, 127, 255, 1)',
          'rgba(0, 63, 255, 1)',
          'rgba(0, 0, 255, 1)',
          'rgba(0, 0, 223, 1)',
          'rgba(0, 0, 191, 1)',
          'rgba(0, 0, 159, 1)',
          'rgba(0, 0, 127, 1)',
          'rgba(63, 0, 91, 1)',
          'rgba(127, 0, 63, 1)',
          'rgba(191, 0, 31, 1)',
          'rgba(255, 0, 0, 1)'
        ]
      }
    }
  }
</GoogleMapComp>
```