### PR TITLE
Remove throw e in google_map.js

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -758,7 +758,6 @@ export default class GoogleMap extends Component {
       })
       .catch(e => {
         console.error(e); // eslint-disable-line no-console
-        throw e;
       });
   };
 


### PR DESCRIPTION
remove `throw e` to allow other reach component to better handle the error in react 15. Having this error makes it difficult for other component to handle this error and probably show their own UI since the execution stops at the line that throws the error