### PR TITLE
Move points-geometry dependency to organization

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "eventemitter3": "^1.1.0",
     "fbjs": "^0.8.3",
-    "point-geometry": "0.0.0",
+    "@mapbox/point-geometry": "^0.1.0",
     "scriptjs": "^2.5.7"
   },
   "devDependencies": {

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -1,4 +1,4 @@
-import Point from 'point-geometry';
+import Point from '@mapbox/point-geometry';
 import LatLng from './lib_geo/lat_lng';
 import Transform from './lib_geo/transform';
 

--- a/src/utils/lib_geo/transform.js
+++ b/src/utils/lib_geo/transform.js
@@ -1,5 +1,5 @@
 /* eslint-disable class-methods-use-this */
-import Point from 'point-geometry';
+import Point from '@mapbox/point-geometry';
 import LatLng from './lat_lng';
 import { wrap } from './wrap';
 


### PR DESCRIPTION
Fixes: 

```
$ npm install

npm WARN deprecated point-geometry@0.0.0: This module has moved: please install @mapbox/point-geometry instead
```
