### PR TITLE
notify call back of load failure

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -757,6 +757,8 @@ export default class GoogleMap extends Component {
         });
       })
       .catch(e => {
+        // notify callback of load failure
+        this._onGoogleApiLoaded({ map: null, maps: null });
         console.error(e); // eslint-disable-line no-console
         throw e;
       });


### PR DESCRIPTION
When the google  fails to load due to no internet, the  call back should be notified so that appropriate UI can be shown