### PR TITLE
Fix for usage from China

### DIFF
--- a/API.md
+++ b/API.md
@@ -15,6 +15,7 @@ Example:
   bootstrapURLKeys={{
     key: API_KEY,
     language: 'ru',
+    region: 'ru',
     ...otherUrlParams,
   }}
 >
@@ -338,3 +339,7 @@ function createMapOptions() {
 The default setting is `gestureHandling:auto` which tries to detect based on the page/content sizes if a `greedy` setting is best (no scrolling is required) or `cooperative` (scrolling is possible)
 
 For more details see the [google documentation](https://developers.google.com/maps/documentation/javascript/interaction) for this setting.
+
+### Localizing the Map
+
+This is done by setting bootstrapURLKeys.[language](https://developers.google.com/maps/documentation/javascript/localization#Language) and bootstrapURLKeys.[region](https://developers.google.com/maps/documentation/javascript/localization#Region). Also notice that setting region to 'cn' is required when using the map from within China, see [google documentation](https://developers.google.com/maps/documentation/javascript/localization#GoogleMapsChina) for more info. Setting 'cn' will result in use of the specific API URL for China.

--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -62,8 +62,10 @@ export default function googleMapLoader(bootstrapURLKeys) {
       ''
     );
 
+    var url = bootstrapURLKeys.region === 'cn' ? 'http://maps.google.cn' : 'https://maps.googleapis.com'
+
     $script_(
-      `https://maps.googleapis.com/maps/api/js?callback=_$_google_map_initialize_$_${queryString}`,
+      `${url}/maps/api/js?callback=_$_google_map_initialize_$_${queryString}`,
       () =>
         typeof window.google === 'undefined' &&
         reject(new Error('google map initialization error (not loaded)'))

--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -62,7 +62,7 @@ export default function googleMapLoader(bootstrapURLKeys) {
       ''
     );
 
-    const url = bootstrapURLKeys.region === 'cn'
+    const url = bootstrapURLKeys.region.toLocaleLowerCase() === 'cn'
       ? 'http://maps.google.cn'
       : 'https://maps.googleapis.com';
 

--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -62,7 +62,9 @@ export default function googleMapLoader(bootstrapURLKeys) {
       ''
     );
 
-    var url = bootstrapURLKeys.region === 'cn' ? 'http://maps.google.cn' : 'https://maps.googleapis.com'
+    const url = bootstrapURLKeys.region === 'cn'
+      ? 'http://maps.google.cn'
+      : 'https://maps.googleapis.com';
 
     $script_(
       `${url}/maps/api/js?callback=_$_google_map_initialize_$_${queryString}`,


### PR DESCRIPTION
Use China specific API URL if setting bootstrapURLKeys.region to 'cn'.

Fixes #493 