### PR TITLE
Added loose to es2015 for IE10, IE11 support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "react", "stage-0"]
+  "presets": [["es2015", {"loose": true}], "react", "stage-0"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lib/*
 dist/*
 /node_modules
+.idea/


### PR DESCRIPTION
IE9 and IE10 require loose to work
    
your demo app doesn't work on IE9/10 so you will need to make a more simple one to test this fix out. the issue is to do with this.props not being avaiable in constructors for IE9/10 see: https://github.com/babel/babel/issues/3975 it was supposidly fixed 1 year ago but I can't see it working, maybe we need to swap to @babel/core to get this fix? I tried it but the change is made larger due to the curent demo apps build system.
    
Full fix would involve upgading to @babel/core + @babel/preset-env and migrating away from kotatsu in favour of a plain ole react app via webpack (create-react-app maybe?) and then place it into another folder and have that folder habing it's own package.json so we can consume google-map-react as if it were a real library during testing. Sure we would loose hmr, but at this stage hmr isn't all that useful anyway.
    
I'de love the proper fix, but for now I have clients with IE10 browser requirements.