### PR TITLE
fix error about fromLatLngToDivPixel

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -717,22 +717,6 @@ export default class GoogleMap extends Component {
             this_._onZoomAnimationEnd();
           }
 
-          const div = overlay.div;
-          const overlayProjection = overlay.getProjection();
-          if (!div || !overlayProjection) {
-            return;
-          }
-          const bounds = map.getBounds();
-          const ne = bounds.getNorthEast();
-          const sw = bounds.getSouthWest();
-          const ptx = overlayProjection.fromLatLngToDivPixel(
-            new maps.LatLng(ne.lat(), sw.lng())
-          );
-          // need round for safari still can't find what need for firefox
-          const ptxRounded = detectBrowser().isSafari
-            ? { x: Math.round(ptx.x), y: Math.round(ptx.y) }
-            : { x: ptx.x, y: ptx.y };
-
           this_.updateCounter_++;
           this_._onBoundsChanged(map, maps);
 
@@ -745,8 +729,25 @@ export default class GoogleMap extends Component {
           this._onChildMouseMove();
 
           this_.dragTime_ = 0;
-          div.style.left = `${ptxRounded.x}px`;
-          div.style.top = `${ptxRounded.y}px`;
+
+          const div = overlay.div;
+          const overlayProjection = overlay.getProjection();
+          if (div && overlayProjection) {
+            const bounds = map.getBounds();
+            const ne = bounds.getNorthEast();
+            const sw = bounds.getSouthWest();
+            const ptx = overlayProjection.fromLatLngToDivPixel(
+              new maps.LatLng(ne.lat(), sw.lng())
+            );
+            // need round for safari still can't find what need for firefox
+            const ptxRounded = detectBrowser().isSafari
+              ? { x: Math.round(ptx.x), y: Math.round(ptx.y) }
+              : { x: ptx.x, y: ptx.y };
+
+            div.style.left = `${ptxRounded.x}px`;
+            div.style.top = `${ptxRounded.y}px`;
+          }
+
           if (this_.markersDispatcher_) {
             this_.markersDispatcher_.emit('kON_CHANGE');
             if (this_.fireMouseEventOnIdle_) {

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -719,6 +719,9 @@ export default class GoogleMap extends Component {
 
           const div = overlay.div;
           const overlayProjection = overlay.getProjection();
+          if (!div || !overlayProjection) {
+            return;
+          }
           const bounds = map.getBounds();
           const ne = bounds.getNorthEast();
           const sw = bounds.getSouthWest();


### PR DESCRIPTION
fix "Cannot read property 'fromLatLngToDivPixel' of undefined" #257

In my production, errors occurred in the `idle` event handler, not in the `draw()` function.

I can not find the condition, but I can reproduce this error in local env.
It looks like below.

<img width="567" alt="2018-02-19 19 56 31" src="https://user-images.githubusercontent.com/856469/36374552-08c671c0-15af-11e8-8087-6c07c336393b.png">
