### PR TITLE
Accept 0 as zoom value.

### DIFF
--- a/API.md
+++ b/API.md
@@ -309,14 +309,13 @@ and if so, uses it, so it won't load a second copy of the library.
 
 ### Override the default minimum zoom
 
-*WARNING*: Setting these options can break markers calculation, causing no homeomorphism between screen coordinates and map.
+*WARNING*: Setting this option can break markers calculation, causing no homeomorphism between screen coordinates and map.
 
-You can use the `minZoomOverride` associated with the `minZoom` in the custom map options to prevent a minimum zoom from being calculated:
+You can use the `minZoom` custom option to prevent our minimum-zoom calculation:
 
 ```javascript
 function createMapOptions() {
   return {
-    minZoomOverride: true,
     minZoom: 2,
   };
 }

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -451,7 +451,7 @@ export default class GoogleMap extends Component {
   };
 
   _computeMinZoom = minZoom => {
-    if (minZoom !== undefined || minZoom !== null) {
+    if (minZoom !== undefined && minZoom !== null) {
       return minZoom;
     }
     return this._getMinZoom();

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -365,10 +365,7 @@ export default class GoogleMap extends Component {
         options = omit(options, ['zoom', 'center', 'draggable']);
 
         if ('minZoom' in options) {
-          const minZoom = this._computeMinZoom(
-            options.minZoomOverride,
-            options.minZoom
-          );
+          const minZoom = this._computeMinZoom(options.minZoom);
           options.minZoom = _checkMinZoom(options.minZoom, minZoom);
         }
 
@@ -453,12 +450,9 @@ export default class GoogleMap extends Component {
     return DEFAULT_MIN_ZOOM;
   };
 
-  _computeMinZoom = (minZoomOverride, minZoom) => {
-    if (minZoomOverride) {
-      if (minZoom !== undefined || minZoom !== null) {
-        return minZoom;
-      }
-      return DEFAULT_MIN_ZOOM;
+  _computeMinZoom = minZoom => {
+    if (minZoom !== undefined || minZoom !== null) {
+      return minZoom;
     }
     return this._getMinZoom();
   };
@@ -549,10 +543,7 @@ export default class GoogleMap extends Component {
           draggable: this.props.draggable,
         };
 
-        const minZoom = this._computeMinZoom(
-          options.minZoomOverride,
-          options.minZoom
-        );
+        const minZoom = this._computeMinZoom(options.minZoom);
         this.minZoom_ = minZoom;
 
         const preMapOptions = {
@@ -703,7 +694,6 @@ export default class GoogleMap extends Component {
           if (this.resetSizeOnIdle_) {
             this._setViewSize();
             const currMinZoom = this._computeMinZoom(
-              this.props.options.minZoomOverride,
               this.props.options.minZoom
             );
 

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -455,7 +455,10 @@ export default class GoogleMap extends Component {
 
   _computeMinZoom = (minZoomOverride, minZoom) => {
     if (minZoomOverride) {
-      return minZoom || DEFAULT_MIN_ZOOM;
+      if (minZoom !== undefined || minZoom !== null) {
+        return minZoom;
+      }
+      return DEFAULT_MIN_ZOOM;
     }
     return this._getMinZoom();
   };


### PR DESCRIPTION
Closes #505 

I removed the `minZoomOverride` option required for overriding the minZoom, I think its pretty clear that if we set a `minZoom`, we want to override it. 

@istarkov please let me know if you set the `minZoomOverride` for other important reason that I am missing, although I checked the code and it does not seem like it.
