### PR TITLE
Set latest release version as default if user does not specify a version.

### DIFF
--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -1,15 +1,26 @@
 /* eslint-disable no-console */
+const BASE_URL = 'https://maps';
+const DEFAULT_URL = `${BASE_URL}.googleapis.com`;
+
+const getUrl = region => {
+  if (region && region.toLowerCase() === 'cn') {
+    return `${BASE_URL}.google.cn`;
+  }
+  return DEFAULT_URL;
+};
+
 let $script_ = null;
 
 let loadPromise_;
 
 let resolveCustomPromise_;
+
 const _customPromise = new Promise(resolve => {
   resolveCustomPromise_ = resolve;
 });
 
 // TODO add libraries language and other map options
-export default function googleMapLoader(bootstrapURLKeys, heatmapLibrary) {
+export default (bootstrapURLKeys, heatmapLibrary) => {
   if (!$script_) {
     $script_ = require('scriptjs'); // eslint-disable-line
   }
@@ -23,6 +34,7 @@ export default function googleMapLoader(bootstrapURLKeys, heatmapLibrary) {
   if (loadPromise_) {
     return loadPromise_;
   }
+
   loadPromise_ = new Promise((resolve, reject) => {
     if (typeof window === 'undefined') {
       reject(new Error('google map cannot be loaded outside browser env'));
@@ -62,13 +74,10 @@ export default function googleMapLoader(bootstrapURLKeys, heatmapLibrary) {
     );
 
     const libraries = heatmapLibrary ? '&libraries=visualization' : '';
-    const url = bootstrapURLKeys.region &&
-      bootstrapURLKeys.region.toLowerCase() === 'cn'
-      ? 'http://maps.google.cn'
-      : 'https://maps.googleapis.com';
+    const baseUrl = getUrl(bootstrapURLKeys.region);
 
     $script_(
-      `${url}/maps/api/js?callback=_$_google_map_initialize_$_${queryString}${libraries}`,
+      `${baseUrl}/maps/api/js?callback=_$_google_map_initialize_$_${queryString}${libraries}`,
       () =>
         typeof window.google === 'undefined' &&
         reject(new Error('google map initialization error (not loaded)'))
@@ -78,4 +87,4 @@ export default function googleMapLoader(bootstrapURLKeys, heatmapLibrary) {
   resolveCustomPromise_(loadPromise_);
 
   return loadPromise_;
-}
+};

--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -1,3 +1,4 @@
+import { isEmpty } from 'lodash';
 /* eslint-disable no-console */
 const BASE_URL = 'https://maps';
 const DEFAULT_URL = `${BASE_URL}.googleapis.com`;
@@ -64,13 +65,20 @@ export default (bootstrapURLKeys, heatmapLibrary) => {
       }
     }
 
-    const queryString = Object.keys(bootstrapURLKeys).reduce(
+    let queryString = Object.keys(bootstrapURLKeys).reduce(
       (r, key) => `${r}&${key}=${bootstrapURLKeys[key]}`,
       ''
     );
 
-    const libraries = heatmapLibrary ? '&libraries=visualization' : '';
+    // if no version is defined, we want to get the release version
+    // and not the experimental version, to do so, we set v=3
+    // src: https://developers.google.com/maps/documentation/javascript/versions
+    if (isEmpty(bootstrapURLKeys.v)) {
+      queryString += `&v=3`;
+    }
+
     const baseUrl = getUrl(bootstrapURLKeys.region);
+    const libraries = heatmapLibrary ? '&libraries=visualization' : '';
 
     $script_(
       `${baseUrl}/maps/api/js?callback=_$_google_map_initialize_$_${queryString}${libraries}`,

--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -57,14 +57,10 @@ export default (bootstrapURLKeys, heatmapLibrary) => {
 
     if (process.env.NODE_ENV !== 'production') {
       if (Object.keys(bootstrapURLKeys).indexOf('callback') > -1) {
-        console.error(
-          '"callback" key in bootstrapURLKeys is not allowed, ' + // eslint-disable-line
-            'use onGoogleApiLoaded property instead'
-        );
-        throw new Error(
-          '"callback" key in bootstrapURLKeys is not allowed, ' +
-            'use onGoogleApiLoaded property instead'
-        );
+        const message = `"callback" key in bootstrapURLKeys is not allowed,
+                          use onGoogleApiLoaded property instead`;
+        console.error(message);
+        throw new Error(message);
       }
     }
 

--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -74,7 +74,7 @@ export default (bootstrapURLKeys, heatmapLibrary) => {
     // and not the experimental version, to do so, we set v=3
     // src: https://developers.google.com/maps/documentation/javascript/versions
     if (isEmpty(bootstrapURLKeys.v)) {
-      queryString += `&v=3`;
+      queryString += `&v=3.31`;
     }
 
     const baseUrl = getUrl(bootstrapURLKeys.region);


### PR DESCRIPTION
Closes #510
Closes #526 

There are a couple of bugs involved in the latest release of Google Maps, both issues (#510 and #526) were caused by the version `3.32` which is **experimental**. [Quoting Google](https://developers.google.com/maps/documentation/javascript/versions):

> The experimental version — currently 3.32 — contains the latest features and bug fixes as they are made publicly available. Changes made to the experimental version are not guaranteed to be feature stable. We encourage you to regularly test your applications with the experimental version, which you can do by adding v=3.32 when loading the API

We would like our default version to be the latest **release** version, and not the latest **experimental** version. To do so we set up `v=3` if no version is specified by the user. Which will be, today 3/10/2018, `3.31`:

> The current release version is 3.31. You can request it with either of the following bootstraps:

```
<script async defer
    src="https://maps.googleapis.com/maps/api/js?v=3
        &key=YOUR_API_KEY&callback=initMap">
```
```
<script async defer
    src="https://maps.googleapis.com/maps/api/js?v=3.31
        &key=YOUR_API_KEY&callback=initMap">
```

I am going to use `3.31` to make sure that this library works, when `3.32` is released, we would need to check if the issues that are affecting us now, will still be affecting us then. But for now, I think this is a good solution, this is also recommended by Google:

> In order to make sure that there are no issues arising from version rollover, we recommend that you explicitly specify the number of the current release version of the API in the bootstrap. For example, v=3.31.

Source: https://developers.google.com/maps/documentation/javascript/versions