### PR TITLE
Use private createHelper from recompose as its not exposed

### DIFF
--- a/develop/utils/props2Stream.js
+++ b/develop/utils/props2Stream.js
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { createHelper } from 'recompose';
+import createHelper from 'recompose/createHelper';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import 'rxjs/add/operator/distinctUntilChanged';
 import createEagerFactory from './createEagerFactory';

--- a/develop/utils/stream2Props.js
+++ b/develop/utils/stream2Props.js
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { createHelper } from 'recompose';
+import createHelper from 'recompose/createHelper';
 import createEagerFactory from './createEagerFactory';
 
 // if stream prop will change this will fail,

--- a/develop/utils/withStateSelector.js
+++ b/develop/utils/withStateSelector.js
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { createHelper } from 'recompose';
+import createHelper from 'recompose/createHelper';
 import createEagerFactory from './createEagerFactory';
 
 const withStateSelector = (stateName, stateUpdaterName, selectorFactory) =>


### PR DESCRIPTION
Introduced in #533 

I did not know that the method createHelper was private in recompose, but after a little bit of research. I found that it is actually not exposed. Source: https://github.com/acdlite/recompose/issues/66

Fixes error:
<img width="859" alt="screen shot 2018-03-12 at 19 35 13" src="https://user-images.githubusercontent.com/6504551/37302719-a5aa1428-262c-11e8-9303-413b709e6480.png">